### PR TITLE
diffusion_transverse_map conifg

### DIFF
--- a/sim_files/fax_config_1t.json
+++ b/sim_files/fax_config_1t.json
@@ -13,8 +13,7 @@
         "survival_probability_map": false,
         "drift_speed_map": false,
         "diffusion_longitudinal_map": false,
-        "diffusion_radial_map": false,
-        "diffusion_azimuthal_map": false},
+        "diffusion_transverse_map": false},
 
     // LXe properties
     "temperature": 177.45,


### PR DESCRIPTION
Changed diffusion_radial_map and diffusion_azimuthal_map to a single configuration, as they would be used together.

**Before uploading files to this repo**
 - This is a public repository. Upload sensitive information to https://github.com/XENONnT/private_nt_aux_files/. These are nT files, files that describe the nT status et cetera*.
 - Add the file to the `README.md` with a short description and preferably a link.

*Guidelines are being drafted (at time of writing: 2020-12-10). Stay tuned.