### PR TITLE
Add g2_mean so WFSim test can pass (please...)

### DIFF
--- a/sim_files/fax_config_1t.json
+++ b/sim_files/fax_config_1t.json
@@ -63,7 +63,8 @@
     "electron_lifetime_liquid": 650000,
     "electron_trapping_time": 140.0,
     "gas_drift_velocity_slope": 5400000000000.0,
-    "g2_mean": 32.3,
+    // https://arxiv.org/pdf/1902.11297.pdf, table 2
+    "g2_mean": 11.4,
 
     // PMT
     "p_double_pe_emision": 0.15,

--- a/sim_files/fax_config_1t.json
+++ b/sim_files/fax_config_1t.json
@@ -63,6 +63,7 @@
     "electron_lifetime_liquid": 650000,
     "electron_trapping_time": 140.0,
     "gas_drift_velocity_slope": 5400000000000.0,
+    "g2_mean": 32.3,
 
     // PMT
     "p_double_pe_emision": 0.15,


### PR DESCRIPTION
**Before uploading files to this repo**
 - This is a public repository. Upload sensitive information to https://github.com/XENONnT/private_nt_aux_files/. These are nT files, files that describe the nT status et cetera*.
 - Add the file to the `README.md` with a short description and preferably a link.

*Guidelines are being drafted (at time of writing: 2020-12-10). Stay tuned.

The xy-dependent SE gain and extraction efficiency pull request has some failing tests because of the missing "g2_mean" parameter that's missing from the 1T fax config.